### PR TITLE
chore: promote jx-aspnet-app-01 to version 0.0.2

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -3,5 +3,6 @@ helmfiles:
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
 - path: helmfiles/jx-staging/helmfile.yaml
+- path: helmfiles/jx-production/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
   url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/jx-aspnet-app-01
-  version: 0.0.1
+  version: 0.0.2
   name: jx-aspnet-app-01
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# jx-aspnet-app-01

## Changes in version 0.0.2

### Chores

* release 0.0.2 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Update Program.cs (hughexp)
