### PR TITLE
chore: promote jx-aspnet-app002 to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-production/jx-aspnet-app002/jx-aspnet-app002-jx-aspnet-app002-deploy.yaml
+++ b/config-root/namespaces/jx-production/jx-aspnet-app002/jx-aspnet-app002-jx-aspnet-app002-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx-aspnet-app002-jx-aspnet-app002
   labels:
     draft: draft-app
-    chart: "jx-aspnet-app002-0.0.2"
+    chart: "jx-aspnet-app002-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx-aspnet-app002'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jx-aspnet-app002-jx-aspnet-app002
       containers:
       - name: jx-aspnet-app002
-        image: "10.104.245.237/hughexp/jx-aspnet-app002:0.0.2"
+        image: "10.104.245.237/hughexp/jx-aspnet-app002:0.0.3"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.2
+          value: 0.0.3
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-production/jx-aspnet-app002/jx-aspnet-app002-svc.yaml
+++ b/config-root/namespaces/jx-production/jx-aspnet-app002/jx-aspnet-app002-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx-aspnet-app002
   labels:
-    chart: "jx-aspnet-app002-0.0.2"
+    chart: "jx-aspnet-app002-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx-aspnet-app002'

--- a/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-jx-aspnet-app002-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-jx-aspnet-app002-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx-aspnet-app002-jx-aspnet-app002
   labels:
     draft: draft-app
-    chart: "jx-aspnet-app002-0.0.2"
+    chart: "jx-aspnet-app002-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx-aspnet-app002'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jx-aspnet-app002-jx-aspnet-app002
       containers:
       - name: jx-aspnet-app002
-        image: "10.104.245.237/hughexp/jx-aspnet-app002:0.0.2"
+        image: "10.104.245.237/hughexp/jx-aspnet-app002:0.0.4"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.2
+          value: 0.0.4
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx-aspnet-app002
   labels:
-    chart: "jx-aspnet-app002-0.0.2"
+    chart: "jx-aspnet-app002-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx-aspnet-app002'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 8c9a66051bfb62d554d483693a0c083c845d1fb7a6a4cfad4e244df134eb7bdc
-        checksum/secret: 7ea7ab43ec144408db3ab070a5fef9a8280d4c7b6049934569611b616c7d444e
+        checksum/secret: 755e11bbe8624fc41e1d3b494c81a487e74b8f78988bd03b71da7acc6a8967ec
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts/
 releases:
 - chart: dev/jx-aspnet-app002
-  version: 0.0.3
+  version: 0.0.4
   name: jx-aspnet-app002
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# jx-aspnet-app002

## Changes in version 0.0.4

### Chores

* release 0.0.4 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Update README.md (hughexp)
