### PR TITLE
chore: promote jx-aspnet-app002 to version 0.0.17

### DIFF
--- a/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: jx-aspnet-app002/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jx-aspnet-app002'
+  name: jx-aspnet-app002
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: jx-aspnet-app002
+            port:
+              number: 80
+    host: jx-aspnet-app002-jx-staging.192.168.49.2.nip.io

--- a/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-jx-aspnet-app002-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-jx-aspnet-app002-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: jx-aspnet-app002/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx-aspnet-app002-jx-aspnet-app002
+  labels:
+    draft: draft-app
+    chart: "jx-aspnet-app002-0.0.17"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx-aspnet-app002'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: jx-aspnet-app002-jx-aspnet-app002
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx-aspnet-app002-jx-aspnet-app002
+    spec:
+      serviceAccountName: jx-aspnet-app002-jx-aspnet-app002
+      containers:
+      - name: jx-aspnet-app002
+        image: "hub-uat.mypaas.com/hughexp/jx-aspnet-app002:0.0.17"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VERSION
+          value: 0.0.17
+        envFrom: null
+        ports:
+        - name: http
+          containerPort: 80
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 400m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+      - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-jx-aspnet-app002-sa.yaml
+++ b/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-jx-aspnet-app002-sa.yaml
@@ -1,0 +1,10 @@
+# Source: jx-aspnet-app002/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx-aspnet-app002-jx-aspnet-app002
+  annotations:
+    meta.helm.sh/release-name: 'jx-aspnet-app002'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx-aspnet-app002/jx-aspnet-app002-svc.yaml
@@ -1,0 +1,20 @@
+# Source: jx-aspnet-app002/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx-aspnet-app002
+  labels:
+    chart: "jx-aspnet-app002-0.0.17"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx-aspnet-app002'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: jx-aspnet-app002-jx-aspnet-app002

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 8c9a66051bfb62d554d483693a0c083c845d1fb7a6a4cfad4e244df134eb7bdc
-        checksum/secret: 116c9df5e3cd494dd91b75bb2cfe8cabddea2d958a37bf2608dfd5cfd28ea22c
+        checksum/secret: acaaf97da35559636f3d6cad643a3da0a6650925ac3f37bea7f02ba99d55a723
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,5 +7,9 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts/
+releases:
+- chart: dev/jx-aspnet-app002
+  version: 0.0.17
+  name: jx-aspnet-app002
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/jx-aspnet-app002
   version: 0.0.17
   name: jx-aspnet-app002
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# jx-aspnet-app002

## Changes in version 0.0.17

### Chores

* release 0.0.17 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Revert "修改应用" (huyc04)
* Update README.md (hughexp)
* 修改应用 (huyc04)
