### PR TITLE
chore: promote jx-aspnet-app002 to version 0.0.17

### DIFF
--- a/config-root/namespaces/jx-production/jx-aspnet-app002/jx-aspnet-app002-jx-aspnet-app002-deploy.yaml
+++ b/config-root/namespaces/jx-production/jx-aspnet-app002/jx-aspnet-app002-jx-aspnet-app002-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx-aspnet-app002-jx-aspnet-app002
   labels:
     draft: draft-app
-    chart: "jx-aspnet-app002-0.0.14"
+    chart: "jx-aspnet-app002-0.0.17"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx-aspnet-app002'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jx-aspnet-app002-jx-aspnet-app002
       containers:
       - name: jx-aspnet-app002
-        image: "hub-uat.mypaas.com/hughexp/jx-aspnet-app002:0.0.14"
+        image: "hub-uat.mypaas.com/hughexp/jx-aspnet-app002:0.0.17"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.14
+          value: 0.0.17
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-production/jx-aspnet-app002/jx-aspnet-app002-svc.yaml
+++ b/config-root/namespaces/jx-production/jx-aspnet-app002/jx-aspnet-app002-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx-aspnet-app002
   labels:
-    chart: "jx-aspnet-app002-0.0.14"
+    chart: "jx-aspnet-app002-0.0.17"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx-aspnet-app002'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 8c9a66051bfb62d554d483693a0c083c845d1fb7a6a4cfad4e244df134eb7bdc
-        checksum/secret: 116c9df5e3cd494dd91b75bb2cfe8cabddea2d958a37bf2608dfd5cfd28ea22c
+        checksum/secret: e96f6ce500839c6ea1a06485f258f24667d51bf543435f0301d6bf9c4691d050
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts/
 releases:
 - chart: dev/jx-aspnet-app002
-  version: 0.0.14
+  version: 0.0.17
   name: jx-aspnet-app002
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# jx-aspnet-app002

## Changes in version 0.0.17

### Chores

* release 0.0.17 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Revert "修改应用" (huyc04)
* Update README.md (hughexp)
* 修改应用 (huyc04)
